### PR TITLE
Set platform window title

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,3 +5,4 @@ linter:
   rules:
     lines_longer_than_80_chars: false
     public_member_api_docs: false
+    directives_ordering: true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,9 +16,9 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:ubuntu_wsl_splash/l10n/app_localizations.dart';
 import 'package:ubuntu_wsl_splash/utils/win32utils.dart';
 import 'package:yaru/yaru.dart';
-import 'package:ubuntu_wsl_splash/l10n/app_localizations.dart';
 
 void main() {
   runApp(const UbuntuWslSplash());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:ubuntu_wsl_splash/utils/win32utils.dart';
 import 'package:yaru/yaru.dart';
 import 'package:ubuntu_wsl_splash/l10n/app_localizations.dart';
 
@@ -31,6 +32,7 @@ class UbuntuWslSplash extends StatelessWidget {
     return MaterialApp(
       onGenerateTitle: (context) {
         final lang = AppLocalizations.of(context);
+        setWindowTitle(lang.windowTitle);
         return lang.appTitle;
       },
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -15,14 +15,16 @@
  *
  */
 
-import 'dart:ffi';
-
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 void setWindowTitle(String title) {
-  final hWnd =
-      FindWindow('FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf16(), nullptr);
+  final windowClass = 'FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf16();
+  final windowName = 'ubuntu_wsl_splash'.toNativeUtf16();
+  final hWnd = FindWindow(windowClass, windowName);
   final titleNative = title.toNativeUtf16();
   SetWindowText(hWnd, titleNative);
+  malloc.free(windowClass);
+  malloc.free(windowName);
+  malloc.free(titleNative);
 }

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -1,0 +1,11 @@
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+void setWindowTitle(String title) {
+  final hWnd =
+      FindWindow('FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf16(), nullptr);
+  final titleNative = title.toNativeUtf16();
+  SetWindowText(hWnd, titleNative);
+}

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -168,6 +175,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  win32:
+    dependency: "direct main"
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.3"
   yaru:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   intl: ^0.17.0
   yaru: ^0.2.0
   yaru_icons: ^0.0.8
+  win32: ^2.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
That's the end result. That title is translatable by the localizations API.
![image](https://user-images.githubusercontent.com/11138291/149004624-7888de94-c69a-4867-900a-63892847708f.png)

By default, that title matches the app package name, as described in `pubspec.yaml`. @jpnurmi did a similar trick for the installer by interacting with GTK code. Here I have the luxury of doing straight from Dart by adding the win32 package. I'm foreseeing other situations where I'll need to interact with Win32 API's in this project, so the dependency is justifiable.