### PR TITLE
Added lint rules for better maintenability

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,3 +6,6 @@ linter:
     lines_longer_than_80_chars: false
     public_member_api_docs: false
     directives_ordering: true
+    sort_pub_dependencies: true
+    avoid_relative_lib_imports: true
+    prefer_relative_imports: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,15 +37,14 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
 
+  win32: ^2.3.0
   yaru: ^0.2.0
   yaru_icons: ^0.0.8
-  win32: ^2.3.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-
   flutter_lints: ^1.0.0
+  flutter_test:
+    sdk: flutter  
 
 flutter:
   generate: true


### PR DESCRIPTION
- Sorting dependencies plays nice with pubspec assist.
- Relative imports can be more readable as long as they don't break out of lib folder.