### PR TITLE
Installer Status Widget

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -37,3 +37,6 @@ const kContentWidthFraction = 0.7;
 
 /// The size of a radio indicator.
 const kRadioSize = Size.square(kMinInteractiveDimension - 8);
+
+/// Size of common elements size inside a Span.
+const kSpanElementSize = 16.0;

--- a/lib/installer_status_widget.dart
+++ b/lib/installer_status_widget.dart
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+
+import 'constants.dart';
+
+class InstallerStatus extends StatelessWidget {
+  const InstallerStatus({
+    Key? key,
+    required this.title,
+    required this.statusIcon,
+    required this.log,
+    required this.maxLines,
+    this.subtitle,
+  }) : super(key: key);
+  final Widget title;
+  final Widget statusIcon;
+  final Widget? subtitle;
+  final Stream<String> log;
+  final int maxLines;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: kSpanElementSize),
+      child: ExpansionTile(
+        title: title,
+        leading: statusIcon,
+        subtitle: subtitle,
+        controlAffinity: ListTileControlAffinity.trailing,
+        childrenPadding: const EdgeInsets.only(left: 3 * kSpanElementSize),
+        expandedAlignment: Alignment.topLeft,
+        children: [
+          LogView(
+            log: log,
+            maxLines: maxLines,
+            padding: const EdgeInsets.symmetric(horizontal: kContentSpacing),
+            style: TextStyle(
+              inherit: false,
+              fontSize: Theme.of(context).textTheme.bodyText2!.fontSize,
+              fontFamily: 'Ubuntu Mono',
+              textBaseline: TextBaseline.alphabetic,
+            ),
+            decoration: const InputDecoration(
+              border: InputBorder.none,
+              contentPadding:
+                  EdgeInsets.symmetric(vertical: kContentSpacing / 2),
+            ),
+            background: BoxDecoration(color: Theme.of(context).shadowColor),
+          ),
+        ],
+        maintainState: true,
+      ),
+    );
+  }
+}

--- a/test/installer_status_widget_test.dart
+++ b/test/installer_status_widget_test.dart
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wsl_splash/installer_status_widget.dart';
+
+void main() {
+  testWidgets("Installer status should keep LogView state when collapsed",
+      (WidgetTester tester) async {
+    const contents = ["Line 1", "Line 2", "Line 3", "Lines 4"];
+    final joined = contents.join('\n');
+    final log = Stream.fromIterable(contents);
+    final status = InstallerStatus(
+        title: const Text("Title"),
+        statusIcon: const Icon(Icons.ac_unit),
+        log: log,
+        maxLines: 4);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: status,
+        ),
+      ),
+    );
+
+    final tile = find.text("Title");
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+
+    expect(find.text(joined), findsWidgets);
+
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    expect(find.text(joined), findsNothing);
+
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    expect(find.text(joined), findsWidgets);
+  });
+}


### PR DESCRIPTION
Builds on top of LogView (`ubuntu-flutter-pluggins/ubuntu-widgets`), the same component used in the U-D-I). It will be used to display the messages coming from the launcher app.

Currently it is not protected against too many log lines, like rsync'ing the snap directories when debugging. That causes the GUI to jank. But that situation is not expected anyway, so let's not focus on it before detecting a real use case under the context of WSL.

This PR aims to provide the bare bones configurable widget. Below is how it looks when fully configured:

![image](https://user-images.githubusercontent.com/11138291/151043143-b9371fe0-97b1-4d09-b111-3c6e869eede3.png)
