### PR TITLE
Integrating the pieces

### DIFF
--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:yaru_icons/widgets/yaru_icons.dart';
+
+import 'constants.dart';
+import 'installer_state_controller.dart';
+import 'installer_status_widget.dart';
+import 'l10n/app_localizations.dart';
+import 'slide.dart';
+import 'slides_page.dart';
+
+class AppHome extends StatefulWidget {
+  const AppHome({
+    Key? key,
+    required this.slides,
+    required this.controller,
+  }) : super(key: key);
+
+  final List<Slide> slides;
+  final InstallerStateController controller;
+
+  @override
+  State<AppHome> createState() => _AppHomeState();
+}
+
+class _AppHomeState extends State<AppHome> {
+  late final InstallerStateController controller;
+
+  @override
+  void initState() {
+    controller = widget.controller;
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SlidesPage(
+      widget.slides,
+      bottom: StreamBuilder<InstallerState>(
+        stream: controller.states,
+        builder: (context, snapshot) {
+          return _buildStatusTile(
+            context,
+            snapshot.data,
+            controller.journal,
+          );
+        },
+      ),
+    );
+  }
+
+// The core of the whole application state.
+  Widget _buildStatusTile(
+    BuildContext context,
+    InstallerState? state,
+    Stream<String> log,
+  ) {
+    late final Widget statusIcon, title;
+    Widget? subtitle;
+    final lang = AppLocalizations.of(context);
+    final errorColor = Theme.of(context).errorColor;
+
+    switch (state) {
+      case null:
+      case InstallerState.initializing:
+        statusIcon = const SizedBox(
+          child: CircularProgressIndicator(),
+          height: kSpanElementSize,
+          width: kSpanElementSize,
+        );
+        title = const Text("Initializing...");
+        break;
+
+      case InstallerState.unpacking:
+        statusIcon = const SizedBox(
+          child: CircularProgressIndicator(),
+          height: kSpanElementSize,
+          width: kSpanElementSize,
+        );
+
+        title = Text(lang.unpacking);
+        break;
+
+      case InstallerState.settingUp:
+        statusIcon = const Icon(
+          YaruIcons.input_tablet,
+        );
+        title = Text(lang.installing);
+        break;
+
+      case InstallerState.running:
+        statusIcon = const SizedBox(
+          child: CircularProgressIndicator(),
+          height: kSpanElementSize,
+          width: kSpanElementSize,
+        );
+        title = Text(lang.launching);
+        break;
+
+      case InstallerState.done:
+        statusIcon = const Icon(
+          Icons.done_all_rounded,
+        );
+        title = Text(lang.done);
+        break;
+
+      case InstallerState.error:
+        statusIcon = Icon(
+          YaruIcons.error_filled,
+          color: errorColor,
+        );
+        title = Text(lang.errorMsg);
+        subtitle = Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(
+            lang.errorSub,
+            style: Theme.of(context).textTheme.caption,
+          ),
+        );
+        break;
+    }
+
+    int maxLines = state == InstallerState.error ? 4 : 5;
+
+    return InstallerStatus(
+      title: title,
+      statusIcon: statusIcon,
+      log: log,
+      maxLines: maxLines,
+      subtitle: subtitle,
+    );
+  }
+}

--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -40,17 +40,9 @@ class AppHome extends StatefulWidget {
 }
 
 class _AppHomeState extends State<AppHome> {
-  late final InstallerStateController controller;
-
-  @override
-  void initState() {
-    controller = widget.controller;
-    super.initState();
-  }
-
   @override
   void dispose() {
-    controller.dispose();
+    widget.controller.dispose();
     super.dispose();
   }
 
@@ -59,12 +51,12 @@ class _AppHomeState extends State<AppHome> {
     return SlidesPage(
       widget.slides,
       bottom: StreamBuilder<InstallerState>(
-        stream: controller.states,
+        stream: widget.controller.states,
         builder: (context, snapshot) {
           return _buildStatusTile(
             context,
             snapshot.data,
-            controller.journal,
+            widget.controller.journal,
           );
         },
       ),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -40,3 +40,6 @@ const kRadioSize = Size.square(kMinInteractiveDimension - 8);
 
 /// Size of common elements size inside a Span.
 const kSpanElementSize = 16.0;
+
+/// The height of the slide page with its descendants.
+const kSlidePageHeight = 460.0;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,5 +3,11 @@
     "appTitle": "What to expect from Ubuntu on WSL",
     "windowTitle": "Installing Ubuntu on WSL",
     "welcome": "Welcome to Ubuntu",
+    "unpacking": "Unpacking the distro",
+    "installing": "Almost done. The installer requires your attention.",
+    "launching": "Launching distro...",
+    "errorMsg": "Something went wrong.",
+    "errorSub": "Please restart WSL with the following command and try again:\n\twsl --shutdown\n\twsl --unregister DISTRO_NAME",
+    "done": "All set. Enjoy using Ubuntu on WSL",
     "ubuntuOnWsl": "Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -110,6 +110,42 @@ abstract class AppLocalizations {
   /// **'Welcome to Ubuntu'**
   String get welcome;
 
+  /// No description provided for @unpacking.
+  ///
+  /// In en, this message translates to:
+  /// **'Unpacking the distro'**
+  String get unpacking;
+
+  /// No description provided for @installing.
+  ///
+  /// In en, this message translates to:
+  /// **'Almost done. The installer requires your attention.'**
+  String get installing;
+
+  /// No description provided for @launching.
+  ///
+  /// In en, this message translates to:
+  /// **'Launching distro...'**
+  String get launching;
+
+  /// No description provided for @errorMsg.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong.'**
+  String get errorMsg;
+
+  /// No description provided for @errorSub.
+  ///
+  /// In en, this message translates to:
+  /// **'Please restart WSL with the following command and try again:\n\twsl --shutdown\n\twsl --unregister DISTRO_NAME'**
+  String get errorSub;
+
+  /// No description provided for @done.
+  ///
+  /// In en, this message translates to:
+  /// **'All set. Enjoy using Ubuntu on WSL'**
+  String get done;
+
   /// No description provided for @ubuntuOnWsl.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -17,5 +17,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcome => 'Welcome to Ubuntu';
 
   @override
+  String get unpacking => 'Unpacking the distro';
+
+  @override
+  String get installing => 'Almost done. The installer requires your attention.';
+
+  @override
+  String get launching => 'Launching distro...';
+
+  @override
+  String get errorMsg => 'Something went wrong.';
+
+  @override
+  String get errorSub => 'Please restart WSL with the following command and try again:\n\twsl --shutdown\n\twsl --unregister DISTRO_NAME';
+
+  @override
+  String get done => 'All set. Enjoy using Ubuntu on WSL';
+
+  @override
   String get ubuntuOnWsl => 'Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows.';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,9 +18,11 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
+import 'app_home.dart';
+import 'installer_state_controller.dart';
 import 'l10n/app_localizations.dart';
 import 'slide.dart';
-import 'slides_page.dart';
+import 'stdin_stream.dart';
 import 'utils/win32utils.dart';
 
 void main() {
@@ -43,8 +45,13 @@ class UbuntuWslSplash extends StatelessWidget {
       theme: yaruLight,
       darkTheme: yaruDark,
       home: Builder(builder: (context) {
-        final slides = theSlides(context);
-        return SlidesPage(slides);
+        return AppHome(
+          controller: InstallerStateController(
+            stdinStream(),
+            InstallerState.initializing,
+          ),
+          slides: theSlides(context),
+        );
       }),
     );
   }

--- a/lib/slides_page.dart
+++ b/lib/slides_page.dart
@@ -18,6 +18,7 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
+import 'constants.dart';
 import 'slide.dart';
 
 /// Implements a slide show in which all slides have a common background image.
@@ -34,10 +35,9 @@ class SlidesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
           SizedBox(
-            height: 460,
+            height: kSlidePageHeight,
             child: Stack(
               children: <Widget>[
                 const Image(

--- a/lib/slides_page.dart
+++ b/lib/slides_page.dart
@@ -25,8 +25,10 @@ import 'slide.dart';
 /// An 'installation status' is (planned to be) shown at the bottom of the page.
 class SlidesPage extends StatelessWidget {
   final List<Slide> slides;
+  final Widget bottom;
 
-  const SlidesPage(this.slides, {Key? key}) : super(key: key);
+  const SlidesPage(this.slides, {required this.bottom, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +46,7 @@ class SlidesPage extends StatelessWidget {
               ),
             ],
           ),
+          bottom,
         ],
       ),
     );

--- a/lib/slides_page.dart
+++ b/lib/slides_page.dart
@@ -34,17 +34,21 @@ class SlidesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
-          Stack(
-            children: <Widget>[
-              const Image(
-                image: AssetImage('assets/bg.jpg'),
-                fit: BoxFit.scaleDown,
-              ),
-              SlideShow(
-                slides: slides,
-              ),
-            ],
+          SizedBox(
+            height: 460,
+            child: Stack(
+              children: <Widget>[
+                const Image(
+                  image: AssetImage('assets/bg.jpg'),
+                  fit: BoxFit.cover,
+                ),
+                SlideShow(
+                  slides: slides,
+                ),
+              ],
+            ),
           ),
           bottom,
         ],

--- a/lib/stdin_stream.dart
+++ b/lib/stdin_stream.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+Stream<String> stdinStream() {
+  if (kDebugMode) {
+    return _debugStream();
+  }
+  return _prodStream();
+}
+
+Stream<String> _debugStream() {
+  const stdoutMessages = [
+    "Installing, this may take a few minutes...",
+    "Installation successful!",
+    "Launching the OOBE",
+    "flutter: INFO ubuntu_wsl_setup: Logging to /var/log/installer/ubuntu_wsl_setup.log",
+    "Error: OOBE not found.",
+  ];
+
+  return Stream.periodic(const Duration(seconds: 2),
+      (index) => stdoutMessages[index % stdoutMessages.length]);
+}
+
+Stream<String> _prodStream() =>
+    stdin.transform(systemEncoding.decoder).transform(const LineSplitter());

--- a/test/app_home_test.dart
+++ b/test/app_home_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wsl_splash/app_home.dart';
+import 'package:ubuntu_wsl_splash/installer_state_controller.dart';
+import 'package:ubuntu_wsl_splash/l10n/app_localizations.dart';
+
+import 'package:ubuntu_wsl_splash/slide.dart';
+import 'package:yaru_icons/widgets/yaru_icons.dart';
+
+void main() {
+  testWidgets('AppHome Installer Status integration',
+      (WidgetTester tester) async {
+    // Given
+    const expectedStates = <InstallerState>[
+      InstallerState.initializing,
+      InstallerState.unpacking,
+      InstallerState.settingUp,
+      InstallerState.running,
+      InstallerState.error,
+      InstallerState.done,
+    ];
+
+    const title = "Ubuntu on WSL";
+    const asset = AssetImage("assets/ubuntu-on-wsl.png");
+
+    const slides = [
+      Slide(image: asset, title: title, text: "1"),
+      Slide(image: asset, title: title, text: "2"),
+      Slide(image: asset, title: title, text: "3"),
+    ];
+    final controller = FakeController();
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+            body: AppHome(
+          slides: slides,
+          controller: controller,
+        )),
+      ),
+    );
+    // When
+
+    for (final state in expectedStates) {
+      controller.add(state);
+      await tester.pump();
+      switch (state) {
+        case InstallerState.initializing:
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          break;
+        case InstallerState.unpacking:
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          break;
+        case InstallerState.settingUp:
+          expect(find.byIcon(YaruIcons.input_tablet), findsOneWidget);
+          break;
+        case InstallerState.running:
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          break;
+        case InstallerState.done:
+          expect(find.byIcon(Icons.done_all_rounded), findsOneWidget);
+          break;
+        case InstallerState.error:
+          expect(find.byIcon(YaruIcons.error_filled), findsOneWidget);
+          break;
+        default:
+          expect(
+            0,
+            1,
+            reason: "All states should be mapped, leave no room for defaults.",
+          );
+          break;
+      }
+    }
+
+    // Then
+  });
+}
+
+/// Fake and dummy controller just to satisfy the widget with the expected API.
+class FakeController implements InstallerStateController {
+  static const stdoutMessages = [
+    "Installing, this may take a few minutes...",
+    "Installation successful!",
+    "Launching the OOBE",
+    "flutter: INFO ubuntu_wsl_setup: Logging to /var/log/installer/ubuntu_wsl_setup.log",
+    "flutter: ERROR ubuntu_wsl_setup: FontConfig cannot find default files",
+    "Error: OOBE not found.",
+  ];
+
+  @override
+  void dispose() {
+    _stateController.close();
+  }
+
+  @override
+  Stream<String> get journal => Stream<String>.fromIterable(stdoutMessages);
+
+  @override
+  void processJournalInput(String line) {
+    //does nothing.
+  }
+
+  @override
+  InstallerState get state => throw UnimplementedError();
+
+  @override
+  Stream<InstallerState> get states => _stateController.stream;
+
+  final _stateController = StreamController<InstallerState>(sync: true);
+
+  void add(InstallerState state) => _stateController.sink.add(state);
+}

--- a/test/slides_page_test.dart
+++ b/test/slides_page_test.dart
@@ -11,6 +11,7 @@ void main() {
   testWidgets('Slides Page test widget', (WidgetTester tester) async {
     const title = "Ubuntu on WSL";
     const asset = AssetImage("assets/ubuntu-on-wsl.png");
+    const bottomText = "This is a test";
 
     const app = MaterialApp(
       home: SlidesPage(
@@ -19,11 +20,12 @@ void main() {
           Slide(image: asset, title: title, text: "2"),
           Slide(image: asset, title: title, text: "3"),
         ],
-        bottom: Text("This is a test"),
+        bottom: Text(bottomText),
       ),
     );
 
     await tester.pumpWidget(app);
+    expect(find.text(bottomText), findsOneWidget);
 
     final rightButton = find.byIcon(Icons.chevron_right);
     expect(rightButton, findsOneWidget);

--- a/test/slides_page_test.dart
+++ b/test/slides_page_test.dart
@@ -13,11 +13,14 @@ void main() {
     const asset = AssetImage("assets/ubuntu-on-wsl.png");
 
     const app = MaterialApp(
-      home: SlidesPage([
-        Slide(image: asset, title: title, text: "1"),
-        Slide(image: asset, title: title, text: "2"),
-        Slide(image: asset, title: title, text: "3"),
-      ]),
+      home: SlidesPage(
+        [
+          Slide(image: asset, title: title, text: "1"),
+          Slide(image: asset, title: title, text: "2"),
+          Slide(image: asset, title: title, text: "3"),
+        ],
+        bottom: Text("This is a test"),
+      ),
     );
 
     await tester.pumpWidget(app);


### PR DESCRIPTION
It turns out that due the simplicity of this app I could keep the state management in one single top-level widget. Thus no need for the provider package.

`AppHome` handles the `InstallerStateController`, making sure it's disposed in the end and reacts to its state change thru the method `_buildStatusTile()` which builds the pieces of the `ListTile` that are affected by the state changes.

I didn't make it stateless because I needed to ensure the controller's `dispose()` method is called. I could have wrapped it in a Provider, but that would be the single reason why I'd bring that dependency to this project. So, to my understanding that is the perfect use case for a stateful widget, even though I don't need to call `setState()`