### PR TITLE
Enables reacting to window close events

### DIFF
--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -15,6 +15,8 @@
  *
  */
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
@@ -24,6 +26,7 @@ import 'installer_status_widget.dart';
 import 'l10n/app_localizations.dart';
 import 'slide.dart';
 import 'slides_page.dart';
+import 'utils/win32utils.dart';
 
 class AppHome extends StatefulWidget {
   const AppHome({
@@ -40,6 +43,51 @@ class AppHome extends StatefulWidget {
 }
 
 class _AppHomeState extends State<AppHome> {
+  @override
+  void initState() {
+    super.initState();
+    SplashWindowCloseNotifier.setWindowCloseHandler(
+      onClose: () async {
+        return await showDialog(
+            context: context,
+            builder: (context) {
+              final lang = AppLocalizations.of(context);
+              return AlertDialog(
+                  title: Text(lang.exitTitle),
+                  content: Text(lang.exitContents),
+                  actions: [
+                    OutlinedButton(
+                      onPressed: () =>
+                          Navigator.of(context, rootNavigator: true).pop(true),
+                      child: const Text("Leave"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text("Cancel"),
+                    ),
+                  ]);
+            });
+      },
+      onCustomClose: () async {
+        return await showDialog(
+            context: context,
+            builder: (context) {
+              final lang = AppLocalizations.of(context);
+              return AlertDialog(
+                  title: Text(lang.customExitTitle),
+                  content: Text(lang.customExitContents),
+                  actions: [
+                    ElevatedButton(
+                        onPressed: () =>
+                            Navigator.of(context, rootNavigator: true)
+                                .pop(true),
+                        child: Text(lang.ok)),
+                  ]);
+            }).timeout(const Duration(seconds: 7), onTimeout: () => true);
+      },
+    );
+  }
+
   @override
   void dispose() {
     widget.controller.dispose();

--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -55,11 +55,11 @@ class _AppHomeState extends State<AppHome> {
                 OutlinedButton(
                   onPressed: () =>
                       Navigator.of(context, rootNavigator: true).pop(true),
-                  child: const Text("Leave"),
+                  child: Text(lang.leave),
                 ),
                 ElevatedButton(
                   onPressed: () => Navigator.of(context).pop(false),
-                  child: const Text("Cancel"),
+                  child: Text(lang.cancel),
                 ),
               ]);
         });
@@ -133,7 +133,7 @@ class _AppHomeState extends State<AppHome> {
           height: kSpanElementSize,
           width: kSpanElementSize,
         );
-        title = const Text("Initializing...");
+        title = Text(lang.initializing);
         break;
 
       case InstallerState.unpacking:

--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -43,48 +43,51 @@ class AppHome extends StatefulWidget {
 }
 
 class _AppHomeState extends State<AppHome> {
+  Future<bool?> _showExitDialog() {
+    return showDialog<bool>(
+        context: context,
+        builder: (context) {
+          final lang = AppLocalizations.of(context);
+          return AlertDialog(
+              title: Text(lang.exitTitle),
+              content: Text(lang.exitContents),
+              actions: [
+                OutlinedButton(
+                  onPressed: () =>
+                      Navigator.of(context, rootNavigator: true).pop(true),
+                  child: const Text("Leave"),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text("Cancel"),
+                ),
+              ]);
+        });
+  }
+
+  Future<bool?> _showCustomExitDialog() {
+    return showDialog<bool>(
+        context: context,
+        builder: (context) {
+          final lang = AppLocalizations.of(context);
+          return AlertDialog(
+              title: Text(lang.customExitTitle),
+              content: Text(lang.customExitContents),
+              actions: [
+                ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context, rootNavigator: true).pop(true),
+                    child: Text(lang.ok)),
+              ]);
+        }).timeout(const Duration(seconds: 7), onTimeout: () => true);
+  }
+
   @override
   void initState() {
     super.initState();
     SplashWindowCloseNotifier.setWindowCloseHandler(
-      onClose: () async {
-        return await showDialog(
-            context: context,
-            builder: (context) {
-              final lang = AppLocalizations.of(context);
-              return AlertDialog(
-                  title: Text(lang.exitTitle),
-                  content: Text(lang.exitContents),
-                  actions: [
-                    OutlinedButton(
-                      onPressed: () =>
-                          Navigator.of(context, rootNavigator: true).pop(true),
-                      child: const Text("Leave"),
-                    ),
-                    ElevatedButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: const Text("Cancel"),
-                    ),
-                  ]);
-            });
-      },
-      onCustomClose: () async {
-        return await showDialog(
-            context: context,
-            builder: (context) {
-              final lang = AppLocalizations.of(context);
-              return AlertDialog(
-                  title: Text(lang.customExitTitle),
-                  content: Text(lang.customExitContents),
-                  actions: [
-                    ElevatedButton(
-                        onPressed: () =>
-                            Navigator.of(context, rootNavigator: true)
-                                .pop(true),
-                        child: Text(lang.ok)),
-                  ]);
-            }).timeout(const Duration(seconds: 7), onTimeout: () => true);
-      },
+      onClose: _showExitDialog,
+      onCustomClose: _showCustomExitDialog,
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,10 +4,15 @@
     "windowTitle": "Installing Ubuntu on WSL",
     "welcome": "Welcome to Ubuntu",
     "unpacking": "Unpacking the distro",
-    "installing": "Almost done. The installer requires your attention.",
+    "installing": "Almost done. The installer will require your attention soon.",
     "launching": "Launching distro...",
     "errorMsg": "Something went wrong.",
     "errorSub": "Please restart WSL with the following command and try again:\n\twsl --shutdown\n\twsl --unregister DISTRO_NAME",
     "done": "All set. Enjoy using Ubuntu on WSL",
+    "exitTitle" : "Are you sure you want to leave?",
+    "exitContents" : "Closing this window will not prevent the installation from continuing in the background.\n\nBesides, you can continue exploring what you can do with Ubuntu on WSL.",
+    "customExitTitle": "We are almost done",
+    "customExitContents" : "Just a few steps to be completed in the main installer window.\nCan we quit this one and go there?",
+    "ok" : "Ok",
     "ubuntuOnWsl": "Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,6 +3,7 @@
     "appTitle": "What to expect from Ubuntu on WSL",
     "windowTitle": "Installing Ubuntu on WSL",
     "welcome": "Welcome to Ubuntu",
+    "initializing" : "Initializing...",
     "unpacking": "Unpacking the distro",
     "installing": "Almost done. The installer will require your attention soon.",
     "launching": "Launching distro...",
@@ -14,5 +15,7 @@
     "customExitTitle": "We are almost done",
     "customExitContents" : "Just a few steps to be completed in the main installer window.\nCan we quit this one and go there?",
     "ok" : "Ok",
+    "leave" : "Leave",
+    "cancel" : "Cancel",
     "ubuntuOnWsl": "Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -119,7 +119,7 @@ abstract class AppLocalizations {
   /// No description provided for @installing.
   ///
   /// In en, this message translates to:
-  /// **'Almost done. The installer requires your attention.'**
+  /// **'Almost done. The installer will require your attention soon.'**
   String get installing;
 
   /// No description provided for @launching.
@@ -145,6 +145,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'All set. Enjoy using Ubuntu on WSL'**
   String get done;
+
+  /// No description provided for @exitTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to leave?'**
+  String get exitTitle;
+
+  /// No description provided for @exitContents.
+  ///
+  /// In en, this message translates to:
+  /// **'Closing this window will not prevent the installation from continuing in the background.\n\nBesides, you can continue exploring what you can do with Ubuntu on WSL.'**
+  String get exitContents;
+
+  /// No description provided for @customExitTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'We are almost done'**
+  String get customExitTitle;
+
+  /// No description provided for @customExitContents.
+  ///
+  /// In en, this message translates to:
+  /// **'Just a few steps to be completed in the main installer window.\nCan we quit this one and go there?'**
+  String get customExitContents;
+
+  /// No description provided for @ok.
+  ///
+  /// In en, this message translates to:
+  /// **'Ok'**
+  String get ok;
 
   /// No description provided for @ubuntuOnWsl.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -110,6 +110,12 @@ abstract class AppLocalizations {
   /// **'Welcome to Ubuntu'**
   String get welcome;
 
+  /// No description provided for @initializing.
+  ///
+  /// In en, this message translates to:
+  /// **'Initializing...'**
+  String get initializing;
+
   /// No description provided for @unpacking.
   ///
   /// In en, this message translates to:
@@ -175,6 +181,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Ok'**
   String get ok;
+
+  /// No description provided for @leave.
+  ///
+  /// In en, this message translates to:
+  /// **'Leave'**
+  String get leave;
+
+  /// No description provided for @cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancel;
 
   /// No description provided for @ubuntuOnWsl.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -17,6 +17,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcome => 'Welcome to Ubuntu';
 
   @override
+  String get initializing => 'Initializing...';
+
+  @override
   String get unpacking => 'Unpacking the distro';
 
   @override
@@ -48,6 +51,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ok => 'Ok';
+
+  @override
+  String get leave => 'Leave';
+
+  @override
+  String get cancel => 'Cancel';
 
   @override
   String get ubuntuOnWsl => 'Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows.';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -20,7 +20,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unpacking => 'Unpacking the distro';
 
   @override
-  String get installing => 'Almost done. The installer requires your attention.';
+  String get installing => 'Almost done. The installer will require your attention soon.';
 
   @override
   String get launching => 'Launching distro...';
@@ -33,6 +33,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get done => 'All set. Enjoy using Ubuntu on WSL';
+
+  @override
+  String get exitTitle => 'Are you sure you want to leave?';
+
+  @override
+  String get exitContents => 'Closing this window will not prevent the installation from continuing in the background.\n\nBesides, you can continue exploring what you can do with Ubuntu on WSL.';
+
+  @override
+  String get customExitTitle => 'We are almost done';
+
+  @override
+  String get customExitContents => 'Just a few steps to be completed in the main installer window.\nCan we quit this one and go there?';
+
+  @override
+  String get ok => 'Ok';
 
   @override
   String get ubuntuOnWsl => 'Install a complete Ubuntu terminal environment in minutes on Windows with Windows Subsystem for Linux (WSL).\n\nAccess the Linux terminal on Windows, develop cross-platform applications, and manage IT infrastructure without leaving Windows.';

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -39,8 +39,8 @@ void setWindowTitle(String title) {
 class SplashWindowCloseNotifier {
   SplashWindowCloseNotifier._();
 
-  static Future<bool> Function()? _onCloseEventHandler;
-  static Future<bool> Function()? _onCustomCloseEventHandler;
+  static Future<bool?> Function()? _onCloseEventHandler;
+  static Future<bool?> Function()? _onCustomCloseEventHandler;
   static MethodChannel? _notificationChannel;
   static const MethodChannel _channel = MethodChannel('splash_window_close');
 
@@ -83,8 +83,8 @@ class SplashWindowCloseNotifier {
   /// });
   /// ```
   static void setWindowCloseHandler(
-      {Future<bool> Function()? onClose,
-      Future<bool> Function()? onCustomClose}) {
+      {Future<bool?> Function()? onClose,
+      Future<bool?> Function()? onCustomClose}) {
     _onCloseEventHandler = onClose;
     _onCustomCloseEventHandler = onCustomClose;
     if (_notificationChannel == null) {
@@ -93,7 +93,7 @@ class SplashWindowCloseNotifier {
         if (call.method == 'onCustomCloseEvent') {
           final handler = SplashWindowCloseNotifier._onCustomCloseEventHandler;
           if (handler != null) {
-            final result = await handler();
+            final result = await handler() ?? false;
             if (result) SplashWindowCloseNotifier.terminateWindow();
           }
         }
@@ -101,7 +101,7 @@ class SplashWindowCloseNotifier {
         if (call.method == 'onWindowClose') {
           final handler = SplashWindowCloseNotifier._onCloseEventHandler;
           if (handler != null) {
-            final result = await handler();
+            final result = await handler() ?? false;
             if (result) SplashWindowCloseNotifier.terminateWindow();
           } else {
             _channel.invokeMethod('quitWindow');

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -41,7 +41,6 @@ class SplashWindowCloseNotifier {
 
   static Future<bool?> Function()? _onCloseEventHandler;
   static Future<bool?> Function()? _onCustomCloseEventHandler;
-  static MethodChannel? _notificationChannel;
   static const MethodChannel _channel = MethodChannel('splash_window_close');
 
   /// Sets a function to handle window close events.
@@ -87,30 +86,27 @@ class SplashWindowCloseNotifier {
       Future<bool?> Function()? onCustomClose}) {
     _onCloseEventHandler = onClose;
     _onCustomCloseEventHandler = onCustomClose;
-    if (_notificationChannel == null) {
-      var channel = const MethodChannel('splash_window_close_notification');
-      channel.setMethodCallHandler((call) async {
-        if (call.method == 'onCustomCloseEvent') {
-          final handler = SplashWindowCloseNotifier._onCustomCloseEventHandler;
-          if (handler != null) {
-            final result = await handler() ?? false;
-            if (result) SplashWindowCloseNotifier.terminateWindow();
-          }
-        }
 
-        if (call.method == 'onWindowClose') {
-          final handler = SplashWindowCloseNotifier._onCloseEventHandler;
-          if (handler != null) {
-            final result = await handler() ?? false;
-            if (result) SplashWindowCloseNotifier.terminateWindow();
-          } else {
-            _channel.invokeMethod('quitWindow');
-          }
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onCustomCloseEvent') {
+        final handler = SplashWindowCloseNotifier._onCustomCloseEventHandler;
+        if (handler != null) {
+          final result = await handler() ?? false;
+          if (result) SplashWindowCloseNotifier.terminateWindow();
         }
-        return null;
-      });
-      _notificationChannel = channel;
-    }
+      }
+
+      if (call.method == 'onWindowClose') {
+        final handler = SplashWindowCloseNotifier._onCloseEventHandler;
+        if (handler != null) {
+          final result = await handler() ?? false;
+          if (result) SplashWindowCloseNotifier.terminateWindow();
+        } else {
+          _channel.invokeMethod('quitWindow');
+        }
+      }
+      return null;
+    });
   }
 
   static void closeWindow() {

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -16,6 +16,7 @@
  */
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter/services.dart';
 import 'package:win32/win32.dart';
 
 void setWindowTitle(String title) {
@@ -27,4 +28,96 @@ void setWindowTitle(String title) {
   malloc.free(windowClass);
   malloc.free(windowName);
   malloc.free(titleNative);
+}
+
+/// A class that helps your Flutter desktop app to handle window close event.
+/// Heavily inspired by package:flutter_window_close.
+/// Having it integrated into the app instead of being a plugin gives direct
+/// access to the window handle, thus there is no possibility of failure if the
+/// call to GetActiveWindow() fails due users interacting with other windows
+/// at the moment of the call.
+class SplashWindowCloseNotifier {
+  SplashWindowCloseNotifier._();
+
+  static Future<bool> Function()? _onCloseEventHandler;
+  static Future<bool> Function()? _onCustomCloseEventHandler;
+  static MethodChannel? _notificationChannel;
+  static const MethodChannel _channel = MethodChannel('splash_window_close');
+
+  /// Sets a function to handle window close events.
+  ///
+  /// When a user click on the close button on a window, the method channel
+  /// redirects the event to your function. The function should return a future
+  /// that returns a boolean indicating whether the user really wants to
+  /// close the window or not. True will let the window to be closed, while
+  /// false let the window to remain open.
+  ///
+  /// By default there is no handler, and the window will be directly closed
+  /// when a window close event happens. You can also reset the handler by
+  /// passing null to the method.
+  ///
+  /// Besides WM_CLOSE, its possible to react to WM_USER+7 code through the
+  /// [onCustomClose] callback. It shares the same phylosophy of [onClose]
+  /// but it's less strict, i.e., does nothing it the parameter is null.
+  /// For the usage in WSL, though, [onCustomClose] is even more important
+  /// because that's the message the launcher will issue.
+  ///
+  /// Example:
+  ///
+  /// ``` dart
+  /// SplashWindowClose.setWindowCloseHandler(onClose: () async {
+  ///     return await showDialog(
+  ///         context: context,
+  ///         builder: (context) {
+  ///           return AlertDialog(
+  ///           title: const Text('Do you really want to quit?'),
+  ///           actions: [
+  ///             ElevatedButton(
+  ///             onPressed: () => Navigator.of(context).pop(true),
+  ///             child: const Text('Yes')),
+  ///             ElevatedButton(
+  ///             onPressed: () => Navigator.of(context).pop(false),
+  ///             child: const Text('No')),
+  ///           ]);
+  ///         }).timeout(const Duration(seconds: 5), onTimeout: ()=>true);
+  /// });
+  /// ```
+  static void setWindowCloseHandler(
+      {Future<bool> Function()? onClose,
+      Future<bool> Function()? onCustomClose}) {
+    _onCloseEventHandler = onClose;
+    _onCustomCloseEventHandler = onCustomClose;
+    if (_notificationChannel == null) {
+      var channel = const MethodChannel('splash_window_close_notification');
+      channel.setMethodCallHandler((call) async {
+        if (call.method == 'onCustomCloseEvent') {
+          final handler = SplashWindowCloseNotifier._onCustomCloseEventHandler;
+          if (handler != null) {
+            final result = await handler();
+            if (result) SplashWindowCloseNotifier.terminateWindow();
+          }
+        }
+
+        if (call.method == 'onWindowClose') {
+          final handler = SplashWindowCloseNotifier._onCloseEventHandler;
+          if (handler != null) {
+            final result = await handler();
+            if (result) SplashWindowCloseNotifier.terminateWindow();
+          } else {
+            _channel.invokeMethod('quitWindow');
+          }
+        }
+        return null;
+      });
+      _notificationChannel = channel;
+    }
+  }
+
+  static void closeWindow() {
+    _channel.invokeMethod('closeWindow');
+  }
+
+  static void terminateWindow() {
+    _channel.invokeMethod('destroyWindow');
+  }
 }

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -3,6 +3,7 @@
 
 #include <flutter/dart_project.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 
 #include <memory>
 
@@ -28,6 +29,9 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // Method channel to notify Dart code with the closing event.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> notificationChannel;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -31,7 +31,7 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 
   // Method channel to notify Dart code with the closing event.
-  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> notificationChannel;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> windowCloseChannel;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_


### PR DESCRIPTION
- Method channel into the FlutterWindow to access its window handle.
- If it was a plugin, indirect methods would be required (more fragile).
- Launcher will send WM_USER+7 message to request close.
- That enables distinguishing between launcher and user close requests.