### PR TITLE
Enables custom messaging for hiding the window

### DIFF
--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -87,7 +87,7 @@ class _AppHomeState extends State<AppHome> {
     super.initState();
     SplashWindowCloseNotifier.setWindowCloseHandler(
       onClose: _showExitDialog,
-      onCustomClose: _showCustomExitDialog,
+      onCustomHide: _showCustomExitDialog,
     );
   }
 

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -40,7 +40,7 @@ class SplashWindowCloseNotifier {
   SplashWindowCloseNotifier._();
 
   static Future<bool?> Function()? _onCloseEventHandler;
-  static Future<bool?> Function()? _onCustomCloseEventHandler;
+  static Future<bool?> Function()? _onCustomHideEventHandler;
   static const MethodChannel _channel = MethodChannel('splash_window_close');
 
   /// Sets a function to handle window close events.
@@ -56,9 +56,9 @@ class SplashWindowCloseNotifier {
   /// passing null to the method.
   ///
   /// Besides WM_CLOSE, its possible to react to WM_USER+7 code through the
-  /// [onCustomClose] callback. It shares the same phylosophy of [onClose]
+  /// [onCustomHide] callback. It shares the same phylosophy of [onClose]
   /// but it's less strict, i.e., does nothing it the parameter is null.
-  /// For the usage in WSL, though, [onCustomClose] is even more important
+  /// For the usage in WSL, though, [onCustomHide] is even more important
   /// because that's the message the launcher will issue.
   ///
   /// Example:
@@ -83,16 +83,16 @@ class SplashWindowCloseNotifier {
   /// ```
   static void setWindowCloseHandler(
       {Future<bool?> Function()? onClose,
-      Future<bool?> Function()? onCustomClose}) {
+      Future<bool?> Function()? onCustomHide}) {
     _onCloseEventHandler = onClose;
-    _onCustomCloseEventHandler = onCustomClose;
+    _onCustomHideEventHandler = onCustomHide;
 
     _channel.setMethodCallHandler((call) async {
-      if (call.method == 'onCustomCloseEvent') {
-        final handler = SplashWindowCloseNotifier._onCustomCloseEventHandler;
+      if (call.method == 'onCustomHideEvent') {
+        final handler = SplashWindowCloseNotifier._onCustomHideEventHandler;
         if (handler != null) {
           final result = await handler() ?? false;
-          if (result) SplashWindowCloseNotifier.terminateWindow();
+          if (result) SplashWindowCloseNotifier.hideWindow();
         }
       }
 

--- a/lib/utils/win32utils.dart
+++ b/lib/utils/win32utils.dart
@@ -116,4 +116,8 @@ class SplashWindowCloseNotifier {
   static void terminateWindow() {
     _channel.invokeMethod('destroyWindow');
   }
+
+  static void hideWindow() {
+    _channel.invokeMethod('hideWindow');
+  }
 }

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -50,6 +50,10 @@ bool FlutterWindow::OnCreate() {
           PostMessage(handle, WM_CLOSE, 0, 0);
           result->Success(flutter::EncodableValue(nullptr));
         }
+        if (call.method_name().compare("hideWindow") == 0) {
+          ShowWindow(handle, SW_HIDE);
+          result->Success(flutter::EncodableValue(nullptr));
+        }
         else if (call.method_name().compare("destroyWindow") == 0) {
           DestroyWindow(handle);
           result->Success(flutter::EncodableValue(nullptr));

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -102,7 +102,11 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
         return 0;
     
     case WM_USER+7:
-        windowCloseChannel->InvokeMethod("onCustomCloseEvent", nullptr);
+        windowCloseChannel->InvokeMethod("onCustomHideEvent", nullptr);
+        return 0;
+
+    case WM_USER+8:
+        DestroyWindow(hwnd);
         return 0;
   }
 


### PR DESCRIPTION
The state in which the WSL launcher application was expected to close the splash actually works best by hiding the splash instead.

This PR changes the semantic and behavior of the message `WM_USER+7` from custom closing to custom hiding (thus the renaming) and adds another message for the actual close, which doesn't require method calls from the higher level API.