### PR TITLE
Make the custom exit dialog non-dismissible

### DIFF
--- a/lib/app_home.dart
+++ b/lib/app_home.dart
@@ -68,6 +68,7 @@ class _AppHomeState extends State<AppHome> {
   Future<bool?> _showCustomExitDialog() {
     return showDialog<bool>(
         context: context,
+        barrierDismissible: false,
         builder: (context) {
           final lang = AppLocalizations.of(context);
           return AlertDialog(


### PR DESCRIPTION
https://github.com/ubuntu/WSL/issues/177 documents the possibility of dismissing the dialog that notifies the user when its time to leave the slide show and interact with the OOBE, halting the installation. Making the dialog non-dismissible gives time for the user to acknowledge the notification and automatically close out in case it doesn't react on time, moving the installation forward.

This closes https://github.com/ubuntu/WSL/issues/177 while we prepare the redesign that will remove the dialog in favor of something smoother.