### PR TITLE
Post WM_CUSTOM_CLOSE instead of calling DestroyWindow()

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -5,6 +5,10 @@
 #include "flutter/standard_method_codec.h"
 #include "flutter/generated_plugin_registrant.h"
 
+// A custom message used to notify the WndProc to destroy the window.
+// See https://devblogs.microsoft.com/oldnewthing/20110926-00/?p=9553
+constexpr auto WM_CUSTOM_CLOSE = WM_USER+8;
+
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
 
@@ -55,7 +59,7 @@ bool FlutterWindow::OnCreate() {
           result->Success(flutter::EncodableValue(nullptr));
         }
         else if (call.method_name().compare("destroyWindow") == 0) {
-          PostMessage(handle, WM_DESTROY, 0, 0);
+          PostMessage(handle, WM_CUSTOM_CLOSE, 0, 0);
           result->Success(flutter::EncodableValue(nullptr));
         }
         else if (call.method_name().compare("quitWindow") == 0) {
@@ -105,7 +109,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
         windowCloseChannel->InvokeMethod("onCustomHideEvent", nullptr);
         return 0;
 
-    case WM_USER+8:
+    case WM_CUSTOM_CLOSE:
         DestroyWindow(hwnd);
         return 0;
   }

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -55,7 +55,7 @@ bool FlutterWindow::OnCreate() {
           result->Success(flutter::EncodableValue(nullptr));
         }
         else if (call.method_name().compare("destroyWindow") == 0) {
-          DestroyWindow(handle);
+          PostMessage(handle, WM_DESTROY, 0, 0);
           result->Success(flutter::EncodableValue(nullptr));
         }
         else if (call.method_name().compare("quitWindow") == 0) {


### PR DESCRIPTION
FlutterWindow parent class has some business logic to perform on close (see the code snippet below). Calling `DistroyWindow()` is part of that.
Doing as previously done (calling `DestroyWindow()` as part of the method channel handler) may skip part of that logic. That could be a cause for the access violation we noticed in the dumps if some other part of the framework attempts to dereference any of the structures cleaned up during the potentially skipped handler. 

PostMessage, on the other, won't wait the message to be handled, thus the framework has the chance to do whatever it needs to. Posting a custom message allows the WndProc to call DestroyWindow, avoiding any possibility of ownership issues.

```cpp
void Win32Window::Destroy() {
  OnDestroy();

  if (window_handle_) {
    DestroyWindow(window_handle_);
    window_handle_ = nullptr;
  }
  if (g_active_window_count == 0) {
    WindowClassRegistrar::GetInstance()->UnregisterWindowClass();
  }
}


LRESULT
Win32Window::MessageHandler(HWND hwnd,
                            UINT const message,
                            WPARAM const wparam,
                            LPARAM const lparam) noexcept {
  switch (message) {
    case WM_DESTROY:
      window_handle_ = nullptr;
      Destroy();
      if (quit_on_close_) {
        PostQuitMessage(0);
      }
      return 0;

...
```