### PR TITLE
Reduces error notifications

### DIFF
--- a/lib/installer_state_controller.dart
+++ b/lib/installer_state_controller.dart
@@ -50,7 +50,7 @@ class InstallerStateController {
   final Map<RegExp, InstallerState> _patternsToStates = {
     RegExp("Installing, this may take a few minutes.*"):
         InstallerState.unpacking,
-    RegExp(".*Error:.*"): InstallerState.error,
+    RegExp("^Error:.*"): InstallerState.error,
     RegExp("^Installation successful!\$"): InstallerState.settingUp,
     RegExp("^Unpacking is complete!\$"): InstallerState.settingUp,
     RegExp("Launching .*"): InstallerState.running,


### PR DESCRIPTION
The setup GUI is more verbose nowadays.
Error messages are shown even when it heals itself.
This regex change makes the splash react only to errors coming from the launcher.

Here is an example that would cause the InstallerStateController to react as if an irrecoverable error has happened. Notice that after a few SocketExceptions we finally get a connection. That's a normal behavior due the late server startup. The regex match is due "(OS **Error:** " part of the log.

```
2022-07-27 12:47:45.733412 INFO subiquity_server: Waiting server up to 30 seconds
2022-07-27 12:47:45.734439 ERROR subiquity_server: SocketException: Connection failed (OS Error: No such file or directory, errno = 2), address = /run/subiquity/socket, port = 0
2022-07-27 12:47:46.736066 ERROR subiquity_server: SocketException: Connection failed (OS Error: No such file or directory, errno = 2), address = /run/subiquity/socket, port = 0
2022-07-27 12:47:47.737158 ERROR subiquity_server: SocketException: Connection failed (OS Error: No such file or directory, errno = 2), address = /run/subiquity/socket, port = 0
2022-07-27 12:47:48.740348 INFO subiquity_client: Opening socket to Endpoint(/run/subiquity/socket )
```