### PR TITLE
Enables producing a full PDB out of the splash app

### DIFF
--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${BINARY_NAME} WIN32
 )
 apply_standard_settings(${BINARY_NAME})
 target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
+target_link_options(${BINARY_NAME} PUBLIC /DEBUG:FULL)
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 add_dependencies(${BINARY_NAME} flutter_assemble)


### PR DESCRIPTION
A bare bones Flutter app on Windows is made of the `flutter_windows.dll` (provided by the framework) and the application runner executable compiled with Visual Studio build tools, with the build system (aka solutions and vcxproj files) generated by a set of CMakelists.txt files.

Program debug database is supplied for the dll, but not for the application runner. Enabling the build system to generate it requires one-line addition to enable it, [per instructions found in this comment](https://github.com/flutter/flutter/issues/98863#issuecomment-1047178402) on Flutter repository.