### PR TITLE
Allow static linking VC runtime libs

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
+# Allows setting the MSVC_RUNTIME_LIBRARY option
+cmake_policy(SET CMP0091 NEW)
 project(ubuntu_wsl_splash LANGUAGES CXX)
 
 set(BINARY_NAME "ubuntu_wsl_splash")
@@ -31,6 +33,8 @@ add_definitions(-DUNICODE -D_UNICODE)
 
 # Compilation settings that should be applied to most targets.
 function(APPLY_STANDARD_SETTINGS TARGET)
+  # Allows statically linking VC Runtime libs in release config.
+  set_property(TARGET ${TARGET} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:DebugDLL>")
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
+# Allows setting the MSVC_RUNTIME_LIBRARY option
+cmake_policy(SET CMP0091 NEW)
 project(runner LANGUAGES CXX)
 
 add_executable(${BINARY_NAME} WIN32


### PR DESCRIPTION
Back in the time we only supported Windows Desktop it was possible to rely on Microsoft Store to deliver a compatible VCLibs package to ensure the required runtime libraries would always be present in the target system.

We cannot rely on that mechanism on Windows Server. Thus we should avoid linking against them dynamically, since CMake 3.15 onwards offers way to do it statically.

The recipe can be applied to any recent Flutter app targeting Windows to avoid the need for shipping msvcp140.dll, vcruntime140.dll and vcruntime140_1.dll libraries. That can be handy for deployment under certain situations, but increases the overall app size since every native plugin (and the runner binary) will be affected by this option (a lot of binary code will be duplicated).

The size increase is irrelevant for the WSL case, because our main size constraint is orders of magnitude bigger than the Flutter-produced binaries.

Relevant documentation about this topic can be found in MS [FAQ about Runtime libs](https://learn.microsoft.com/en-US/troubleshoot/developer/visualstudio/cpp/libraries/faq-standard-cpp-library#what-is-difference-between-crt-and-standard-c---library--what-libraries-will-runtime-library-compiler-options-include), CMake [CMP0091 policy](https://cmake.org/cmake/help/latest/policy/CMP0091.html#:~:text=Runtime%20library%20selection%20typically%20varies%20with%20build%20configuration,edit%20their%20cache%20entries%20to%20adjust%20the%20flags.) and [MSVC_RUNTIME_LIBRARY property](https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html#prop_tgt:MSVC_RUNTIME_LIBRARY)

Notice the usage of generator expressions in the snippet `"MultiThreaded$<$<CONFIG:Debug>:DebugDLL>"` to ensure we still link against the debug runtime DLL's in debug builds, otherwise those builds would be much bigger and likely slower than they currently are.